### PR TITLE
fix: bring formula more in line with homebrew standards

### DIFF
--- a/Formula/frankenphp.rb
+++ b/Formula/frankenphp.rb
@@ -22,19 +22,21 @@ class Frankenphp < Formula
 
   def install
     php_config = "#{Formula["shivammathur/php/php-zts"].opt_bin}/php-config"
+    php_config_libs = Utils.safe_popen_read(php_config, "--libs").strip
+    
     lib_path = OS.mac? ? " -L#{MacOS.sdk_path_if_needed}/usr/lib" : ""
 
-    ENV["CGO_CFLAGS"] = `#{php_config} --includes`
-    ENV["CGO_LDFLAGS"] = `#{php_config} --ldflags`.strip! + " " + `#{php_config} --libs`.strip! + lib_path
+    ENV["CGO_CFLAGS"] = Utils.safe_popen_read(php_config, "--includes")
+    ENV["CGO_LDFLAGS"] = Utils.safe_popen_read(php_config, "--ldflags").strip + php_config_libs + lib_path
 
+    tags = %w[nobadger nomysql nopgx]
     ldflags = %W[
       -s -w
       -X "github.com/caddyserver/caddy/v2.CustomVersion=FrankenPHP #{version} (Homebrew) PHP #{Formula["shivammathur/php/php-zts"].version} Caddy"
     ]
 
     cd "caddy/frankenphp" do
-      system "go", "build", \
-        *std_go_args(ldflags:, output: bin/"frankenphp"), "-tags", "nobadger,nomysql,nopgx", "main.go"
+      system "go", "build", *std_go_args(ldflags:, tags:), "main.go"
     end
   end
 


### PR DESCRIPTION
Hi, I just discovered frankenphp and am very exited to try it. But as a Homebrew maintainer I had some notes on how the formula can be made a little cleaner.

- `Utils.safe_popen_read` works better than backticks because it has more checks before returning the data. 
- The default output of `go build` is `bin/name` so no need to specify it
- Go tags can be passed as a parameter, making the result a little easier to read.