### PR TITLE
update test runners

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13, macos-15]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-15, macos-15-intel]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/13045

macos-13 is deprecated and will be removed in the near future

we can use ubuntu-24 on x86_64 and aarch64, the php-zts formula is compatible with arm.